### PR TITLE
Implement Microsoft COFF exporter

### DIFF
--- a/src/main/java/ghidra/app/util/DropDownOption.java
+++ b/src/main/java/ghidra/app/util/DropDownOption.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util;
+
+import java.awt.Component;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.swing.JComboBox;
+
+public class DropDownOption<T> extends Option {
+	private final Map<T, String> values;
+	private final Map<String, T> reverseValues = new HashMap<>();
+	private final Class<T> class_;
+	private final T defaultValue;
+	private final JComboBox<String> comp;
+
+	public DropDownOption(String group, String name, Map<T, String> values, Class<T> class_,
+			T defaultValue) {
+		super(group, name, defaultValue);
+
+		this.values = values;
+		for (Map.Entry<T, String> entry : values.entrySet()) {
+			this.reverseValues.put(entry.getValue(), entry.getKey());
+		}
+
+		this.defaultValue = defaultValue;
+		this.class_ = class_;
+
+		this.comp = new JComboBox<String>(values.values().toArray(new String[values.size()]));
+		this.comp.setSelectedItem(values.get(defaultValue));
+	}
+
+	@Override
+	public Component getCustomEditorComponent() {
+		return comp;
+	}
+
+	@Override
+	public Option copy() {
+		return new DropDownOption<T>(getGroup(), getName(), values, class_, defaultValue);
+	}
+
+	@Override
+	public T getValue() {
+		return reverseValues.get(comp.getSelectedItem());
+	}
+
+	@Override
+	public Class<?> getValueClass() {
+		return class_;
+	}
+}

--- a/src/main/java/ghidra/app/util/EnumDropDownOption.java
+++ b/src/main/java/ghidra/app/util/EnumDropDownOption.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class EnumDropDownOption<T extends Enum<T>> extends DropDownOption<T> {
+	public EnumDropDownOption(String group, String name, Class<T> class_, T defaultValue) {
+		super(group, name, Arrays.stream(class_.getEnumConstants())
+				.collect(Collectors.toMap(v -> v, T::toString)),
+			class_, defaultValue);
+	}
+}

--- a/src/main/java/ghidra/app/util/ProgramUtil.java
+++ b/src/main/java/ghidra/app/util/ProgramUtil.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util;
+
+import ghidra.framework.model.DomainObject;
+import ghidra.program.model.listing.Program;
+
+public class ProgramUtil {
+	public static Program getProgram(DomainObject domainObj) {
+		if (!(domainObj instanceof Program)) {
+			return null;
+		}
+		return (Program) domainObj;
+	}
+}

--- a/src/main/java/ghidra/app/util/exporter/CoffRelocatableObjectExporter.java
+++ b/src/main/java/ghidra/app/util/exporter/CoffRelocatableObjectExporter.java
@@ -1,0 +1,474 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.exporter;
+
+import static ghidra.app.util.ProgramUtil.getProgram;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
+
+import ghidra.app.util.DomainObjectService;
+import ghidra.app.util.DropDownOption;
+import ghidra.app.util.EnumDropDownOption;
+import ghidra.app.util.Option;
+import ghidra.app.util.OptionUtils;
+import ghidra.app.util.bin.format.coff.CoffMachineType;
+import ghidra.app.util.bin.format.coff.CoffSymbolStorageClass;
+import ghidra.app.util.bin.format.pe.SectionFlags;
+import ghidra.app.util.exporter.coff.CoffRelocatableObject;
+import ghidra.app.util.exporter.coff.CoffRelocatableSection;
+import ghidra.app.util.exporter.coff.CoffRelocatableSectionRelocationTable;
+import ghidra.app.util.exporter.coff.CoffRelocatableStringTable;
+import ghidra.app.util.exporter.coff.CoffRelocatableSymbol;
+import ghidra.app.util.exporter.coff.CoffRelocatableSymbolTable;
+import ghidra.app.util.exporter.coff.mapper.CoffRelocationTypeMapper;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.framework.model.DomainObject;
+import ghidra.program.model.address.AddressSet;
+import ghidra.program.model.address.AddressSetView;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.Memory;
+import ghidra.program.model.mem.MemoryAccessException;
+import ghidra.program.model.mem.MemoryBlock;
+import ghidra.program.model.relocobj.Relocation;
+import ghidra.program.model.relocobj.RelocationTable;
+import ghidra.program.model.symbol.Symbol;
+import ghidra.util.DataConverter;
+import ghidra.util.LittleEndianDataConverter;
+import ghidra.util.classfinder.ClassSearcher;
+import ghidra.util.task.TaskMonitor;
+
+/**
+ * An exporter implementation that exports COFF object files.
+ */
+public class CoffRelocatableObjectExporter extends Exporter {
+	private Program program;
+	private AddressSetView fileSet;
+	private int machine;
+	private LeadingUnderscore leadingUnderscore;
+	private final CoffRelocatableStringTable stringTable = new CoffRelocatableStringTable();
+	private final Map<String, Integer> symbolNameToNumber = new HashMap<>();
+
+	private static final String OPTION_GROUP_COFF_HEADER = "COFF header";
+	private static final String OPTION_GROUP_SYMBOLS = "Symbols";
+
+	private static final String OPTION_COFF_MACHINE = "COFF machine";
+	private static final String OPTION_LEADING_UNDERSCORE = "Leading underscore";
+
+	private enum LeadingUnderscore {
+		DO_NOTHING("Do nothing"),
+		PREPEND("Prepend"),
+		PREPEND_CDECL("Prepend to cdecl functions"),
+		STRIP("Strip");
+
+		private final String label;
+
+		LeadingUnderscore(String label) {
+			this.label = label;
+		}
+
+		@Override
+		public String toString() {
+			return label;
+		}
+	}
+
+	private static final Map<Short, String> COFF_MACHINES = new TreeMap<>(Map.ofEntries(
+		Map.entry(CoffMachineType.IMAGE_FILE_MACHINE_UNKNOWN, "(none)"),
+		Map.entry(CoffMachineType.IMAGE_FILE_MACHINE_I386, "i386"),
+		Map.entry(CoffMachineType.IMAGE_FILE_MACHINE_AMD64, "x86_64"),
+		Map.entry(CoffMachineType.IMAGE_FILE_MACHINE_ARM, "ARM"),
+		Map.entry(CoffMachineType.IMAGE_FILE_MACHINE_ARM64, "AARCH64"),
+		Map.entry(CoffMachineType.IMAGE_FILE_MACHINE_POWERPC, "PowerPC"),
+		Map.entry(CoffMachineType.IMAGE_FILE_MACHINE_RISCV32, "RISC-V"),
+		Map.entry(CoffMachineType.IMAGE_FILE_MACHINE_RISCV64, "RV64"),
+		Map.entry(CoffMachineType.IMAGE_FILE_MACHINE_R3000, "MIPS (R3000)"),
+		Map.entry(CoffMachineType.IMAGE_FILE_MACHINE_R4000, "MIPS (R4000)")));
+
+	private static final class ProcessorInfo {
+		String processor;
+		int pointerSize;
+
+		public ProcessorInfo(String processor, int pointerSize) {
+			this.processor = processor;
+			this.pointerSize = pointerSize;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (!(obj instanceof ProcessorInfo info)) {
+				return false;
+			}
+
+			return processor.equals(info.processor) && pointerSize == info.pointerSize;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(processor, pointerSize);
+		}
+	}
+
+	private static final Map<ProcessorInfo, Short> GHIDRA_TO_COFF_MACHINES = Map.ofEntries(
+		Map.entry(new ProcessorInfo("x86", 4), CoffMachineType.IMAGE_FILE_MACHINE_I386),
+		Map.entry(new ProcessorInfo("x86", 8), CoffMachineType.IMAGE_FILE_MACHINE_AMD64),
+		Map.entry(new ProcessorInfo("ARM", 4), CoffMachineType.IMAGE_FILE_MACHINE_ARM),
+		Map.entry(new ProcessorInfo("AARCH64", 8), CoffMachineType.IMAGE_FILE_MACHINE_ARM64),
+		Map.entry(new ProcessorInfo("PowerPC", 4), CoffMachineType.IMAGE_FILE_MACHINE_POWERPC),
+		Map.entry(new ProcessorInfo("RISCV", 4), CoffMachineType.IMAGE_FILE_MACHINE_RISCV32),
+		Map.entry(new ProcessorInfo("RISCV", 8), CoffMachineType.IMAGE_FILE_MACHINE_RISCV64),
+		Map.entry(new ProcessorInfo("MIPS", 4), CoffMachineType.IMAGE_FILE_MACHINE_R4000),
+		Map.entry(new ProcessorInfo("PSX", 4), CoffMachineType.IMAGE_FILE_MACHINE_R3000));
+
+	private static short autodetectCoffMachine(Program program) {
+		String processor = program.getLanguage().getProcessor().toString();
+		int pointerSize = program.getDefaultPointerSize();
+		ProcessorInfo info = new ProcessorInfo(processor, pointerSize);
+
+		for (Map.Entry<ProcessorInfo, Short> entry : GHIDRA_TO_COFF_MACHINES.entrySet()) {
+			if (info.equals(entry.getKey())) {
+				return entry.getValue();
+			}
+		}
+
+		return CoffMachineType.IMAGE_FILE_MACHINE_UNKNOWN;
+	}
+
+	private static LeadingUnderscore autodetectLeadingUnderscore(Program program) {
+		if (autodetectCoffMachine(program) == CoffMachineType.IMAGE_FILE_MACHINE_I386) {
+			return LeadingUnderscore.PREPEND;
+		}
+		return LeadingUnderscore.DO_NOTHING;
+	}
+
+	private static CoffRelocationTypeMapper findRelocationTypeMapperFor(
+			int machine, MessageLog log) {
+		List<CoffRelocationTypeMapper> mappers =
+			ClassSearcher.getInstances(CoffRelocationTypeMapper.class)
+					.stream()
+					.filter(s -> s.canApply(machine))
+					.toList();
+
+		if (mappers.isEmpty()) {
+			log.appendMsg("No applicable ELF relocation type mappers found");
+			return null;
+		}
+
+		CoffRelocationTypeMapper mapper = mappers.get(0);
+		if (mappers.size() > 1) {
+			log.appendMsg("Multiple applicable ELF relocation type mappers found, using " +
+				mapper.getClass().getName());
+		}
+
+		return mapper;
+	}
+
+	public CoffRelocatableObjectExporter() {
+		super("COFF relocatable object", "obj", null);
+	}
+
+	@Override
+	public List<Option> getOptions(DomainObjectService domainObjectService) {
+		Program program = getProgram(domainObjectService.getDomainObject());
+		if (program == null) {
+			return EMPTY_OPTIONS;
+		}
+
+		Option[] options = new Option[] {
+			new DropDownOption<>(OPTION_GROUP_COFF_HEADER, OPTION_COFF_MACHINE, COFF_MACHINES,
+				Short.class, autodetectCoffMachine(program)),
+			new EnumDropDownOption<>(OPTION_GROUP_SYMBOLS,
+				OPTION_LEADING_UNDERSCORE, LeadingUnderscore.class,
+				autodetectLeadingUnderscore(program)),
+		};
+
+		return Arrays.asList(options);
+	}
+
+	@Override
+	public void setOptions(List<Option> options) {
+		machine = OptionUtils.getOption(OPTION_COFF_MACHINE, options,
+			CoffMachineType.IMAGE_FILE_MACHINE_UNKNOWN);
+		leadingUnderscore =
+			OptionUtils.getOption(OPTION_LEADING_UNDERSCORE, options, LeadingUnderscore.DO_NOTHING);
+	}
+
+	public String getCoffSymbolName(String symbolName, BooleanSupplier isCdecl) {
+		switch (leadingUnderscore) {
+			case PREPEND_CDECL:
+				if (!isCdecl.getAsBoolean()) {
+					break;
+				}
+
+			case PREPEND:
+				symbolName = "_" + symbolName;
+				break;
+
+			case STRIP:
+				if (symbolName.startsWith("_")) {
+					symbolName = symbolName.substring(1);
+				}
+				break;
+
+			default:
+				break;
+		}
+
+		return symbolName;
+	}
+
+	public String getCoffSymbolName(Symbol symbol) {
+		String symbolName = symbol.getName();
+		BooleanSupplier isCdecl = () -> symbol.getObject() instanceof Function func &&
+			Objects.equals(func.getCallingConventionName(), "__cdecl");
+		return getCoffSymbolName(symbolName, isCdecl);
+	}
+
+	private class Section {
+		private final short number;
+		private final MemoryBlock memoryBlock;
+		private final String name;
+		private final AddressSetView sectionSet;
+		private final Relocation[] relocations;
+		private final byte[] data;
+		private CoffRelocatableSectionRelocationTable relocationTable;
+
+		public Section(short number, MemoryBlock memoryBlock, AddressSetView sectionSet,
+				Predicate<Relocation> predicateRelocation, RelocationTable relocationTable)
+				throws MemoryAccessException {
+			this.number = number;
+			this.memoryBlock = memoryBlock;
+			this.name = memoryBlock.getName();
+			this.sectionSet = sectionSet;
+			List<Relocation> relocations = new ArrayList<>();
+			relocationTable.getRelocations(sectionSet, predicateRelocation)
+					.forEachRemaining(relocations::add);
+			this.relocations = relocations.toArray(new Relocation[0]);
+			if (memoryBlock.isInitialized()) {
+				this.data =
+					relocationTable.getOriginalBytes(sectionSet, DataConverter.getInstance(false),
+						false, predicateRelocation);
+			}
+			else {
+				this.data = null;
+			}
+		}
+
+		public short headerRelocationCount() {
+			if (relocations.length > 65535) {
+				return (short) 65535;
+			}
+			else {
+				return (short) relocations.length;
+			}
+		}
+
+		public void addSymbols(CoffRelocatableSymbolTable.Builder symbolTableBuilder,
+				CoffRelocatableStringTable stringTable) {
+			AddressSet memoryBlockSet =
+				new AddressSet(memoryBlock.getStart(), memoryBlock.getEnd()).intersect(fileSet);
+			for (Symbol symbol : program.getSymbolTable().getAllSymbols(true)) {
+				if (!symbol.isPrimary() || !memoryBlockSet.contains(symbol.getAddress())) {
+					continue;
+				}
+				long offset =
+					Relocation.getAddressOffsetWithinSet(memoryBlockSet, symbol.getAddress());
+				String symbolName = symbol.getName();
+				var obj = symbol.getObject();
+				short type = 0x00;
+				byte storageClass = (byte) CoffSymbolStorageClass.C_STAT;
+				if (obj instanceof Function) {
+					type |= 0x20;
+					storageClass = CoffSymbolStorageClass.C_EXT;
+				}
+				var symbolBuilder =
+					new CoffRelocatableSymbol.Builder(stringTable, getCoffSymbolName(symbol))
+							.setValue((int) offset)
+							.setSectionNumber(number)
+							.setType(type)
+							.setStorageClass(storageClass);
+				int symbolIndex = symbolTableBuilder.addSymbol(symbolBuilder.build());
+				symbolNameToNumber.put(symbolName, symbolIndex);
+			}
+		}
+
+		public void buildCoffRelocationTable(CoffRelocationTypeMapper relocationTypeMapper) {
+			var coffRelocationTableBuilder = new CoffRelocatableSectionRelocationTable.Builder();
+			for (Relocation relocation : relocations) {
+				int offset =
+					(int) Relocation.getAddressOffsetWithinSet(sectionSet, relocation.getAddress());
+				int symbolIndex = symbolNameToNumber.getOrDefault(relocation.getSymbolName(), -1);
+				short type = relocationTypeMapper.apply(relocation, log);
+				coffRelocationTableBuilder
+						.addRelocation(new CoffRelocatableSectionRelocationTable.Relocation(offset,
+							symbolIndex, type));
+			}
+			relocationTable = coffRelocationTableBuilder.build();
+		}
+
+		public CoffRelocatableSection buildCoffSection(CoffRelocatableStringTable stringTable) {
+			int characteristics = 0;
+			if (memoryBlock.isRead()) {
+				characteristics |= SectionFlags.IMAGE_SCN_MEM_READ.getMask();
+			}
+			if (memoryBlock.isWrite()) {
+				characteristics |= SectionFlags.IMAGE_SCN_MEM_WRITE.getMask();
+			}
+			if (memoryBlock.isExecute()) {
+				characteristics |= SectionFlags.IMAGE_SCN_MEM_EXECUTE.getMask();
+			}
+			if (memoryBlock.isInitialized()) {
+				characteristics |= SectionFlags.IMAGE_SCN_CNT_INITIALIZED_DATA.getMask();
+			}
+			return new CoffRelocatableSection.Builder(relocationTable, stringTable,
+				memoryBlock.getName())
+						.setCharacteristics(characteristics)
+						.setData(data)
+						.build();
+		}
+	}
+
+	private List<Section> calculateSections(CoffRelocatableSymbolTable.Builder symbolTableBuilder,
+			Predicate<Relocation> predicateRelocation, RelocationTable relocationTable)
+			throws ExporterException {
+		List<Section> sections = new ArrayList<>();
+		for (MemoryBlock memoryBlock : program.getMemory().getBlocks()) {
+			AddressSet memoryBlockSet =
+				new AddressSet(memoryBlock.getStart(), memoryBlock.getEnd()).intersect(fileSet);
+			if (memoryBlockSet.isEmpty()) {
+				continue;
+			}
+			Section section;
+			try {
+				section = new Section(
+					(short) (sections.size() + 1),
+					memoryBlock,
+					memoryBlockSet,
+					predicateRelocation,
+					relocationTable);
+			}
+			catch (MemoryAccessException e) {
+				throw new ExporterException(e);
+			}
+			sections.add(section);
+			symbolTableBuilder.addSectionSymbol(
+				section.name,
+				section.number,
+				(int) memoryBlock.getSize(),
+				section.headerRelocationCount());
+			section.addSymbols(symbolTableBuilder, stringTable);
+		}
+		return sections;
+	}
+
+	private void calculateExternalSymbols(RelocationTable relocationTable,
+			Predicate<Relocation> predicateRelocation, Memory memory,
+			CoffRelocatableSymbolTable.Builder symbolTableBuilder) {
+		final AddressSetView finalFileSet = fileSet;
+		for (Relocation relocation : (Iterable<Relocation>) () -> relocationTable
+				.getRelocations(finalFileSet, predicateRelocation)) {
+			final String symbolName = relocation.getSymbolName();
+			if (symbolName != null && !symbolNameToNumber.containsKey(symbolName) &&
+				memory.contains(relocation.getAddress())) {
+				// TODO: should plumb the symbol through instead, this is pretty convoluted and probably not right
+				Optional<Symbol> symbol =
+					Arrays.stream(program.getSymbolTable().getSymbols(relocation.getAddress()))
+							.filter((sym -> Objects.equals(sym.getName(), symbolName)))
+							.findFirst();
+				String coffSymbolName = symbol.isPresent() ? getCoffSymbolName(symbol.get())
+						: getCoffSymbolName(symbolName, () -> false);
+				int symbolIndex = symbolTableBuilder.addSymbol(
+					new CoffRelocatableSymbol.Builder(stringTable, coffSymbolName)
+							.setSectionNumber((short) 0)
+							.setType((short) 0x20)
+							.setStorageClass((byte) CoffSymbolStorageClass.C_EXT)
+							.build());
+				symbolNameToNumber.put(symbolName, symbolIndex);
+			}
+		}
+	}
+
+	@Override
+	public boolean export(File file, DomainObject domainObj, AddressSetView fileSet,
+			TaskMonitor taskMonitor) throws ExporterException, IOException {
+		program = getProgram(domainObj);
+		if (program == null) {
+			return false;
+		}
+		Memory memory = program.getMemory();
+		if (fileSet == null) {
+			fileSet = memory;
+		}
+		this.fileSet = fileSet;
+
+		taskMonitor.setIndeterminate(true);
+
+		CoffRelocationTypeMapper relocationTypeMapper = findRelocationTypeMapperFor(machine, log);
+		if (relocationTypeMapper == null) {
+			throw new RuntimeException("No relocation type mapper found for machine");
+		}
+
+		RelocationTable relocationTable = RelocationTable.get(program);
+		final AddressSetView predicateSet = fileSet;
+		Predicate<Relocation> predicateRelocation =
+			(Relocation r) -> r.isNeeded(program, predicateSet);
+		final CoffRelocatableSymbolTable.Builder symbolTableBuilder =
+			new CoffRelocatableSymbolTable.Builder(stringTable);
+		symbolTableBuilder.addFileSymbol(file.getName());
+
+		taskMonitor.setMessage("Calculating sections.");
+		List<Section> sections =
+			calculateSections(symbolTableBuilder, predicateRelocation, relocationTable);
+
+		taskMonitor.setMessage("Calculating external symbols.");
+		calculateExternalSymbols(relocationTable, predicateRelocation, memory, symbolTableBuilder);
+
+		taskMonitor.setMessage("Building COFF symbol table.");
+		final CoffRelocatableSymbolTable symbolTable = symbolTableBuilder.build();
+
+		taskMonitor.setMessage("Building COFF relocation tables.");
+		for (Section section : sections) {
+			section.buildCoffRelocationTable(relocationTypeMapper);
+		}
+
+		taskMonitor.setMessage("Building COFF sections.");
+		final CoffRelocatableObject.Builder objectBuilder =
+			new CoffRelocatableObject.Builder(symbolTable, stringTable)
+					.setMachine((short) machine);
+		for (Section section : sections) {
+			objectBuilder.addSection(section.buildCoffSection(stringTable));
+		}
+
+		taskMonitor.setMessage("Building COFF object.");
+		final CoffRelocatableObject object = objectBuilder.build();
+
+		taskMonitor.setMessage("Writing COFF object to disk.");
+		try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+			object.write(raf, new LittleEndianDataConverter());
+		}
+		return true;
+	}
+}

--- a/src/main/java/ghidra/app/util/exporter/ElfRelocatableObjectExporter.java
+++ b/src/main/java/ghidra/app/util/exporter/ElfRelocatableObjectExporter.java
@@ -31,6 +31,7 @@ import java.util.stream.StreamSupport;
 
 import ghidra.app.util.DomainObjectService;
 import ghidra.app.util.DropDownOption;
+import ghidra.app.util.EnumDropDownOption;
 import ghidra.app.util.Option;
 import ghidra.app.util.OptionUtils;
 import ghidra.app.util.bin.format.elf.ElfConstants;
@@ -342,14 +343,6 @@ public class ElfRelocatableObjectExporter extends Exporter {
 		generateRelocationTables = OptionUtils.getOption(OPTION_GEN_REL, options, false);
 		relocationTableFormat =
 			OptionUtils.getOption(OPTION_REL_FMT, options, ElfSectionHeaderConstants.SHT_NULL);
-	}
-
-	private class EnumDropDownOption<T extends Enum<T>> extends DropDownOption<T> {
-		public EnumDropDownOption(String group, String name, Class<T> class_, T defaultValue) {
-			super(group, name, Arrays.stream(class_.getEnumConstants())
-					.collect(Collectors.toMap(v -> v, T::toString)),
-				class_, defaultValue);
-		}
 	}
 
 	private class Section {

--- a/src/main/java/ghidra/app/util/exporter/ElfRelocatableObjectExporter.java
+++ b/src/main/java/ghidra/app/util/exporter/ElfRelocatableObjectExporter.java
@@ -13,7 +13,6 @@
  */
 package ghidra.app.util.exporter;
 
-import java.awt.Component;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -30,9 +29,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import javax.swing.JComboBox;
-
 import ghidra.app.util.DomainObjectService;
+import ghidra.app.util.DropDownOption;
 import ghidra.app.util.Option;
 import ghidra.app.util.OptionUtils;
 import ghidra.app.util.bin.format.elf.ElfConstants;
@@ -344,50 +342,6 @@ public class ElfRelocatableObjectExporter extends Exporter {
 		generateRelocationTables = OptionUtils.getOption(OPTION_GEN_REL, options, false);
 		relocationTableFormat =
 			OptionUtils.getOption(OPTION_REL_FMT, options, ElfSectionHeaderConstants.SHT_NULL);
-	}
-
-	private class DropDownOption<T> extends Option {
-		private final Map<T, String> values;
-		private final Map<String, T> reverseValues = new HashMap<>();
-		private final Class<T> class_;
-		private final T defaultValue;
-		private final JComboBox<String> comp;
-
-		public DropDownOption(String group, String name, Map<T, String> values, Class<T> class_,
-				T defaultValue) {
-			super(group, name, defaultValue);
-
-			this.values = values;
-			for (Map.Entry<T, String> entry : values.entrySet()) {
-				this.reverseValues.put(entry.getValue(), entry.getKey());
-			}
-
-			this.defaultValue = defaultValue;
-			this.class_ = class_;
-
-			this.comp = new JComboBox<String>(values.values().toArray(new String[values.size()]));
-			this.comp.setSelectedItem(values.get(defaultValue));
-		}
-
-		@Override
-		public Component getCustomEditorComponent() {
-			return comp;
-		}
-
-		@Override
-		public Option copy() {
-			return new DropDownOption<T>(getGroup(), getName(), values, class_, defaultValue);
-		}
-
-		@Override
-		public T getValue() {
-			return reverseValues.get(comp.getSelectedItem());
-		}
-
-		@Override
-		public Class<?> getValueClass() {
-			return class_;
-		}
 	}
 
 	private class EnumDropDownOption<T extends Enum<T>> extends DropDownOption<T> {

--- a/src/main/java/ghidra/app/util/exporter/ElfRelocatableObjectExporter.java
+++ b/src/main/java/ghidra/app/util/exporter/ElfRelocatableObjectExporter.java
@@ -34,6 +34,7 @@ import ghidra.app.util.DropDownOption;
 import ghidra.app.util.EnumDropDownOption;
 import ghidra.app.util.Option;
 import ghidra.app.util.OptionUtils;
+import ghidra.app.util.ProgramUtil;
 import ghidra.app.util.bin.format.elf.ElfConstants;
 import ghidra.app.util.bin.format.elf.ElfSectionHeaderConstants;
 import ghidra.app.util.bin.format.elf.ElfSymbol;
@@ -300,7 +301,7 @@ public class ElfRelocatableObjectExporter extends Exporter {
 
 	@Override
 	public List<Option> getOptions(DomainObjectService domainObjectService) {
-		Program program = getProgram(domainObjectService.getDomainObject());
+		Program program = ProgramUtil.getProgram(domainObjectService.getDomainObject());
 		if (program == null) {
 			return EMPTY_OPTIONS;
 		}
@@ -544,7 +545,7 @@ public class ElfRelocatableObjectExporter extends Exporter {
 	@Override
 	public boolean export(File file, DomainObject domainObj, AddressSetView fileSet,
 			TaskMonitor taskMonitor) throws IOException, ExporterException {
-		program = getProgram(domainObj);
+		program = ProgramUtil.getProgram(domainObj);
 		if (program == null) {
 			return false;
 		}
@@ -623,13 +624,6 @@ public class ElfRelocatableObjectExporter extends Exporter {
 		}
 
 		return true;
-	}
-
-	public static Program getProgram(DomainObject domainObj) {
-		if (!(domainObj instanceof Program)) {
-			return null;
-		}
-		return (Program) domainObj;
 	}
 
 	private void computeSymbolNamesRelocationFileSet(RelocationTable relocationTable,

--- a/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableObject.java
+++ b/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableObject.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.exporter.coff;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.ArrayList;
+import java.util.List;
+
+import ghidra.app.util.bin.format.Writeable;
+import ghidra.app.util.bin.format.pe.MachineConstants;
+import ghidra.util.DataConverter;
+
+public class CoffRelocatableObject implements Writeable {
+	public final static int FILE_HEADER_OFFSET = 0;
+	public final static int FILE_HEADER_SIZE = 20;
+	public final static int SECTION_HEADERS_OFFSET = FILE_HEADER_OFFSET + FILE_HEADER_SIZE;
+
+	private final CoffRelocatableSection[] sections;
+	private final CoffRelocatableSymbolTable symbolTable;
+	private final CoffRelocatableStringTable stringTable;
+	private final short machine;
+	private final int timeDateStamp;
+	private final int characteristics;
+
+	public final static class Builder {
+		private final List<CoffRelocatableSection> sections = new ArrayList<>();
+		private final CoffRelocatableSymbolTable symbolTable;
+		private final CoffRelocatableStringTable stringTable;
+		private short machine = MachineConstants.IMAGE_FILE_MACHINE_UNKNOWN;
+		private int timeDateStamp = 0;
+		private int characteristics = 0;
+
+		public Builder(CoffRelocatableSymbolTable symbolTable,
+				CoffRelocatableStringTable stringTable) {
+			this.symbolTable = symbolTable;
+			this.stringTable = stringTable;
+		}
+
+		public Builder setMachine(short machine) {
+			this.machine = machine;
+			return this;
+		}
+
+		public Builder setTimeDateStamp(int timeDateStamp) {
+			this.timeDateStamp = timeDateStamp;
+			return this;
+		}
+
+		public Builder setCharacteristics(int characteristics) {
+			this.characteristics = characteristics;
+			return this;
+		}
+
+		public Builder addSection(CoffRelocatableSection section) {
+			sections.add(section);
+			return this;
+		}
+
+		public CoffRelocatableObject build() {
+			return new CoffRelocatableObject(this);
+		}
+	}
+
+	private CoffRelocatableObject(CoffRelocatableObject.Builder builder) {
+		this.sections = builder.sections.toArray(new CoffRelocatableSection[0]);
+		this.symbolTable = builder.symbolTable;
+		this.stringTable = builder.stringTable;
+		this.machine = builder.machine;
+		this.timeDateStamp = builder.timeDateStamp;
+		this.characteristics = builder.characteristics;
+		layout();
+	}
+
+	private void layout() {
+		int position =
+			SECTION_HEADERS_OFFSET + sections.length * CoffRelocatableSection.HEADER_SIZE;
+		for (CoffRelocatableSection section : sections) {
+			byte[] data = section.getData();
+			if (data != null) {
+				section.dataOffset = position;
+				position += data.length;
+			}
+		}
+		for (CoffRelocatableSection section : sections) {
+			var relocationTable = section.getRelocationTable();
+			relocationTable.offset = position;
+			position += relocationTable.size();
+		}
+		symbolTable.offset = position;
+	}
+
+	public CoffRelocatableSymbolTable getSymbolTable() {
+		return symbolTable;
+	}
+
+	@Override
+	public void write(RandomAccessFile raf, DataConverter dc) throws IOException {
+		raf.seek(0);
+		raf.setLength(0);
+		byte[] fileHeader = new byte[FILE_HEADER_SIZE];
+		dc.putShort(fileHeader, 0, machine);
+		dc.putShort(fileHeader, 2, (short) sections.length);
+		dc.putInt(fileHeader, 4, timeDateStamp);
+		dc.putInt(fileHeader, 8, symbolTable.offset);
+		dc.putInt(fileHeader, 12, symbolTable.getHeaderSymbolCount());
+		dc.putShort(fileHeader, 16, (short) 0);
+		dc.putShort(fileHeader, 18, (short) characteristics);
+		raf.write(fileHeader);
+		for (CoffRelocatableSection section : sections) {
+			section.write(raf, dc);
+		}
+		for (CoffRelocatableSection section : sections) {
+			raf.write(section.getData());
+		}
+		for (CoffRelocatableSection section : sections) {
+			section.getRelocationTable().write(raf, dc);
+		}
+		symbolTable.write(raf, dc);
+		stringTable.write(raf, dc);
+	}
+}

--- a/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableSection.java
+++ b/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableSection.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.exporter.coff;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import ghidra.app.util.bin.format.pe.SectionHeader;
+import ghidra.util.DataConverter;
+
+public class CoffRelocatableSection {
+	public final static int HEADER_SIZE = 40;
+
+	private final CoffRelocatableSectionRelocationTable relocationTable;
+	private final String shortName;
+	private final int longNameIndex;
+	private final int virtualSize;
+	private final int virtualAddress;
+	private final int characteristics;
+	private final byte[] data;
+	protected int dataOffset;
+
+	public final static class Builder {
+		private final CoffRelocatableSectionRelocationTable relocationTable;
+		private final String shortName;
+		private final int longNameIndex;
+		private int virtualSize = 0;
+		private int virtualAddress = 0;
+		private int characteristics = 0;
+		private byte[] data = null;
+
+		public Builder(CoffRelocatableSectionRelocationTable relocationTable,
+				CoffRelocatableStringTable stringTable, String name) {
+			this.relocationTable = relocationTable;
+			if (name.length() <= 8) {
+				this.shortName = name;
+				this.longNameIndex = 0;
+			}
+			else {
+				this.shortName = null;
+				this.longNameIndex = stringTable.add(name);
+			}
+		}
+
+		public Builder setVirtualSize(int virtualSize) {
+			this.virtualSize = virtualSize;
+			return this;
+		}
+
+		public Builder setVirtualAddress(int virtualAddress) {
+			this.virtualAddress = virtualAddress;
+			return this;
+		}
+
+		public Builder setCharacteristics(int characteristics) {
+			this.characteristics = characteristics;
+			return this;
+		}
+
+		public Builder setData(byte[] data) {
+			this.data = data;
+			return this;
+		}
+
+		public CoffRelocatableSection build() {
+			return new CoffRelocatableSection(this);
+		}
+	}
+
+	private CoffRelocatableSection(Builder builder) {
+		this.relocationTable = builder.relocationTable;
+		this.shortName = builder.shortName;
+		this.longNameIndex = builder.longNameIndex;
+		this.virtualSize = builder.virtualSize;
+		this.virtualAddress = builder.virtualAddress;
+		this.characteristics = builder.characteristics;
+		this.data = builder.data;
+	}
+
+	public CoffRelocatableSectionRelocationTable getRelocationTable() {
+		return relocationTable;
+	}
+
+	public byte[] getData() {
+		return data;
+	}
+
+	public void write(DataOutput out, DataConverter dc) throws IOException {
+		byte[] header = new byte[HEADER_SIZE];
+		if (shortName != null) {
+			byte[] nameBytes = shortName.getBytes(StandardCharsets.UTF_8);
+			System.arraycopy(nameBytes, 0, header, 0, nameBytes.length);
+		}
+		else if (longNameIndex > 0) {
+			byte[] nameBytes = String.format("/%d", longNameIndex).getBytes(StandardCharsets.UTF_8);
+			System.arraycopy(nameBytes, 0, header, 0, nameBytes.length);
+		}
+		else {
+			throw new RuntimeException("Couldn't serialize section name");
+		}
+		dc.putInt(header, 8, virtualSize);
+		dc.putInt(header, 12, virtualAddress);
+		if (data != null) {
+			dc.putInt(header, 16, data.length);
+			dc.putInt(header, 20, dataOffset);
+		}
+		else {
+			dc.putInt(header, 16, 0);
+			dc.putInt(header, 20, 0);
+		}
+		dc.putInt(header, 24, relocationTable.offset);
+		dc.putInt(header, 28, 0);
+		dc.putShort(header, 32, relocationTable.headerCount());
+		dc.putShort(header, 34, (short) 0);
+		int sectionCharacteristics = characteristics;
+		if (relocationTable.linkOverflow()) {
+			sectionCharacteristics |= SectionHeader.IMAGE_SCN_LNK_NRELOC_OVFL;
+		}
+		dc.putInt(header, 36, sectionCharacteristics);
+		out.write(header);
+	}
+}

--- a/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableSectionRelocationTable.java
+++ b/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableSectionRelocationTable.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.exporter.coff;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import ghidra.util.DataConverter;
+
+public class CoffRelocatableSectionRelocationTable {
+	public final static int RECORD_SIZE = 10;
+
+	protected int offset;
+
+	public static final class Relocation {
+		int virtualAddress;
+		int symbol;
+		short type;
+
+		public Relocation(int virtualAddress, int symbol, short type) {
+			this.virtualAddress = virtualAddress;
+			this.symbol = symbol;
+			this.type = type;
+		}
+	}
+
+	public static final class Builder {
+		private final List<Relocation> relocations = new ArrayList<>();
+
+		public void addRelocation(Relocation relocation) {
+			relocations.add(relocation);
+		}
+
+		public CoffRelocatableSectionRelocationTable build() {
+			return new CoffRelocatableSectionRelocationTable(this);
+		}
+	}
+
+	private final Relocation[] relocations;
+
+	private CoffRelocatableSectionRelocationTable(Builder builder) {
+		relocations = builder.relocations.toArray(new Relocation[0]);
+	}
+
+	public boolean linkOverflow() {
+		return relocations.length > 65535;
+	}
+
+	public short headerCount() {
+		if (linkOverflow()) {
+			return (short) 65535;
+		}
+		return (short) relocations.length;
+	}
+
+	public int size() {
+		return (linkOverflow() ? RECORD_SIZE : 0) + (relocations.length * RECORD_SIZE);
+	}
+
+	public void write(DataOutput out, DataConverter dc) throws IOException {
+		byte[] record = new byte[RECORD_SIZE];
+		if (linkOverflow()) {
+			dc.putInt(record, 0, relocations.length);
+			dc.putInt(record, 4, 0);
+			dc.putShort(record, 8, (short) 0);
+			out.write(record);
+		}
+		for (Relocation relocation : relocations) {
+			dc.putInt(record, 0, relocation.virtualAddress);
+			dc.putInt(record, 4, relocation.symbol);
+			dc.putShort(record, 8, relocation.type);
+			out.write(record);
+		}
+	}
+}

--- a/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableStringTable.java
+++ b/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableStringTable.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.exporter.coff;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import ghidra.util.DataConverter;
+
+public final class CoffRelocatableStringTable {
+	private final TreeMap<Integer, byte[]> table = new TreeMap<>();
+	private final Map<String, Integer> reverseTable = new HashMap<>();
+	private int length = 4;
+
+	public long getLength() {
+		return length;
+	}
+
+	public int add(String string) {
+		if (string == null) {
+			throw new NullPointerException();
+		}
+
+		int index = indexOf(string);
+		if (index != 0) {
+			return index;
+		}
+
+		ByteBuffer stringBuffer = StandardCharsets.UTF_8.encode(string);
+		byte[] bytes = Arrays.copyOf(stringBuffer.array(), stringBuffer.limit());
+
+		int nextKey = length;
+		table.put(nextKey, bytes);
+		reverseTable.put(string, nextKey);
+		length += bytes.length + 1;
+		return nextKey;
+	}
+
+	public int indexOf(String string) {
+		return reverseTable.getOrDefault(string, 0);
+	}
+
+	public void write(DataOutput out, DataConverter dc) throws IOException {
+		byte[] header = new byte[4];
+		dc.putInt(header, length);
+		out.write(header);
+		for (byte[] stringBuffer : table.values()) {
+			out.write(stringBuffer);
+			out.writeByte(0);
+		}
+	}
+}

--- a/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableSymbol.java
+++ b/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableSymbol.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.exporter.coff;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+
+import ghidra.util.DataConverter;
+
+public class CoffRelocatableSymbol {
+	public final static int SYMBOL_SIZE = 18;
+
+	private final String shortName;
+	private final int longNameIndex;
+	private final int value;
+	private final short sectionNumber;
+	private final short type;
+	private final byte storageClass;
+	private final CoffRelocatableSymbolAux[] auxSymbols;
+	private final int auxSymbolCount;
+	protected int index;
+
+	public final static class Builder {
+		private final String shortName;
+		private final int longNameIndex;
+		private final ArrayList<CoffRelocatableSymbolAux> auxSymbols = new ArrayList<>();
+		private int auxSymbolCount = 0;
+
+		private int value;
+		private short sectionNumber;
+		private short type;
+		private byte storageClass;
+
+		public Builder setValue(int value) {
+			this.value = value;
+			return this;
+		}
+
+		public Builder setSectionNumber(short sectionNumber) {
+			this.sectionNumber = sectionNumber;
+			return this;
+		}
+
+		public Builder setType(short type) {
+			this.type = type;
+			return this;
+		}
+
+		public Builder setStorageClass(byte storageClass) {
+			this.storageClass = storageClass;
+			return this;
+		}
+
+		public Builder addAuxSymbol(CoffRelocatableSymbolAux symbol) {
+			auxSymbols.add(symbol);
+			auxSymbolCount += symbol.symbolCount();
+			return this;
+		}
+
+		public Builder(CoffRelocatableStringTable stringTable, String name) {
+			if (name.getBytes(StandardCharsets.UTF_8).length <= 8) {
+				this.shortName = name;
+				this.longNameIndex = 0;
+			}
+			else {
+				this.shortName = null;
+				this.longNameIndex = stringTable.add(name);
+			}
+		}
+
+		public CoffRelocatableSymbol build() {
+			return new CoffRelocatableSymbol(this);
+		}
+	}
+
+	private CoffRelocatableSymbol(Builder builder) {
+		this.shortName = builder.shortName;
+		this.longNameIndex = builder.longNameIndex;
+		this.value = builder.value;
+		this.sectionNumber = builder.sectionNumber;
+		this.type = builder.type;
+		this.storageClass = builder.storageClass;
+		this.auxSymbols = builder.auxSymbols.toArray(new CoffRelocatableSymbolAux[0]);
+		this.auxSymbolCount = builder.auxSymbolCount;
+	}
+
+	public int symbolCount() {
+		return 1 + auxSymbolCount;
+	}
+
+	public void write(DataOutput out, DataConverter dc) throws IOException {
+		byte[] symbol = new byte[SYMBOL_SIZE];
+		if (shortName != null) {
+			byte[] nameBytes = shortName.getBytes(StandardCharsets.UTF_8);
+			System.arraycopy(nameBytes, 0, symbol, 0, nameBytes.length);
+		}
+		else if (longNameIndex > 0) {
+			dc.putInt(symbol, 0, 0);
+			dc.putInt(symbol, 4, longNameIndex);
+		}
+		else {
+			throw new RuntimeException("Couldn't serialize symbol name");
+		}
+		dc.putInt(symbol, 8, value);
+		dc.putShort(symbol, 12, sectionNumber);
+		dc.putShort(symbol, 14, type);
+		symbol[16] = storageClass;
+		symbol[17] = (byte) auxSymbolCount;
+		out.write(symbol);
+
+		for (CoffRelocatableSymbolAux aux : auxSymbols) {
+			out.write(aux.toBytes(dc));
+		}
+	}
+}

--- a/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableSymbolAux.java
+++ b/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableSymbolAux.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.exporter.coff;
+
+import java.io.IOException;
+
+import ghidra.util.DataConverter;
+
+public interface CoffRelocatableSymbolAux {
+	public byte[] toBytes(DataConverter dc) throws IOException;
+
+	/**
+	 * @return The number of aux symbol slots this symbol occupies.
+	 */
+	public int symbolCount();
+}

--- a/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableSymbolAuxFile.java
+++ b/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableSymbolAuxFile.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.exporter.coff;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import ghidra.util.DataConverter;
+
+public class CoffRelocatableSymbolAuxFile implements CoffRelocatableSymbolAux {
+	private final byte[] nameBytes;
+
+	public CoffRelocatableSymbolAuxFile(String name) {
+		ByteBuffer nameBuffer = StandardCharsets.UTF_8.encode(name);
+		int paddedLen = ((nameBuffer.limit() + 17) / 18) * 18;
+
+		this.nameBytes = Arrays.copyOf(nameBuffer.array(), paddedLen);
+	}
+
+	@Override
+	public byte[] toBytes(DataConverter dc) {
+		return nameBytes;
+	}
+
+	@Override
+	public int symbolCount() {
+		return nameBytes.length / 18;
+	}
+}

--- a/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableSymbolAuxSectionDefinition.java
+++ b/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableSymbolAuxSectionDefinition.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.exporter.coff;
+
+import ghidra.util.DataConverter;
+
+public class CoffRelocatableSymbolAuxSectionDefinition implements CoffRelocatableSymbolAux {
+	private final int length;
+	private final short numRelocations;
+
+	public CoffRelocatableSymbolAuxSectionDefinition(int length, short numRelocations) {
+		this.length = length;
+		this.numRelocations = numRelocations;
+	}
+
+	@Override
+	public byte[] toBytes(DataConverter dc) {
+		byte[] symbol = new byte[CoffRelocatableSymbol.SYMBOL_SIZE];
+		dc.putInt(symbol, 0, length);
+		dc.putShort(symbol, numRelocations);
+		return symbol;
+	}
+
+	@Override
+	public int symbolCount() {
+		return 1;
+	}
+}

--- a/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableSymbolTable.java
+++ b/src/main/java/ghidra/app/util/exporter/coff/CoffRelocatableSymbolTable.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.exporter.coff;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.TreeMap;
+
+import ghidra.app.util.bin.format.coff.CoffSymbolStorageClass;
+import ghidra.util.DataConverter;
+
+public class CoffRelocatableSymbolTable {
+	private final TreeMap<Integer, CoffRelocatableSymbol> symbolTable;
+	private final int headerSymbolCount;
+	protected int offset;
+
+	public final static class Builder {
+		private final CoffRelocatableStringTable stringTable;
+		private final TreeMap<Integer, CoffRelocatableSymbol> symbolTable = new TreeMap<>();
+		private int headerSymbolCount = 0;
+
+		public int addSymbol(CoffRelocatableSymbol symbol) {
+			int symbolNumber = headerSymbolCount;
+			symbolTable.put(symbolNumber, symbol);
+			headerSymbolCount += symbol.symbolCount();
+			return symbolNumber;
+		}
+
+		public int addFileSymbol(String fileName) {
+			var fileSymbol = new CoffRelocatableSymbol.Builder(stringTable, ".file")
+					.setType((short) 0)
+					.setSectionNumber((short) 65534)
+					.setStorageClass((byte) 103)
+					.addAuxSymbol(new CoffRelocatableSymbolAuxFile(fileName))
+					.build();
+			return addSymbol(fileSymbol);
+		}
+
+		public int addSectionSymbol(String sectionName, short sectionNumber, int length,
+				short numRelocations) {
+			var sectionSymbol = new CoffRelocatableSymbol.Builder(stringTable, sectionName)
+					.setType((short) 0)
+					.setSectionNumber(sectionNumber)
+					.setStorageClass((byte) CoffSymbolStorageClass.C_STAT)
+					.addAuxSymbol(
+						new CoffRelocatableSymbolAuxSectionDefinition(length, numRelocations))
+					.build();
+			return addSymbol(sectionSymbol);
+		}
+
+		public Builder(CoffRelocatableStringTable stringTable) {
+			this.stringTable = stringTable;
+		}
+
+		public CoffRelocatableSymbolTable build() {
+			return new CoffRelocatableSymbolTable(this);
+		}
+	}
+
+	private CoffRelocatableSymbolTable(Builder builder) {
+		symbolTable = builder.symbolTable;
+		headerSymbolCount = builder.headerSymbolCount;
+	}
+
+	public int getHeaderSymbolCount() {
+		return headerSymbolCount;
+	}
+
+	public void write(DataOutput out, DataConverter dc) throws IOException {
+		for (var value : symbolTable.values()) {
+			value.write(out, dc);
+		}
+	}
+}

--- a/src/main/java/ghidra/app/util/exporter/coff/mapper/CoffRelocationTypeMapper.java
+++ b/src/main/java/ghidra/app/util/exporter/coff/mapper/CoffRelocationTypeMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.exporter.coff.mapper;
+
+import ghidra.app.util.importer.MessageLog;
+import ghidra.program.model.relocobj.Relocation;
+import ghidra.util.classfinder.ExtensionPoint;
+
+public interface CoffRelocationTypeMapper extends ExtensionPoint {
+	public short apply(Relocation r, MessageLog log);
+
+	public boolean canApply(int machine);
+}

--- a/src/main/java/ghidra/app/util/exporter/coff/mapper/X86RelocationTypeMapper.java
+++ b/src/main/java/ghidra/app/util/exporter/coff/mapper/X86RelocationTypeMapper.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ghidra.app.util.exporter.coff.mapper;
+
+import ghidra.app.util.bin.format.coff.CoffMachineType;
+import ghidra.app.util.bin.format.coff.relocation.X86_32_CoffRelocationHandler;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.program.model.relocobj.Relocation;
+import ghidra.program.model.relocobj.RelocationAbsolute;
+import ghidra.program.model.relocobj.RelocationRelativePC;
+
+public class X86RelocationTypeMapper implements CoffRelocationTypeMapper {
+	@Override
+	public short apply(Relocation r, MessageLog log) {
+		if (r instanceof RelocationAbsolute rel) {
+			int width = rel.getWidth();
+			switch (width) {
+				case 4:
+					return X86_32_CoffRelocationHandler.IMAGE_REL_I386_DIR32;
+				default:
+					log.appendMsg(String.format(
+						"Unknown RelocationAbsolute width %d at %s", width, r.getAddress()));
+					return X86_32_CoffRelocationHandler.IMAGE_REL_I386_ABSOLUTE;
+			}
+		}
+		else if (r instanceof RelocationRelativePC) {
+			RelocationRelativePC rel = (RelocationRelativePC) r;
+			int width = rel.getWidth();
+			switch (width) {
+				case 4:
+					return X86_32_CoffRelocationHandler.IMAGE_REL_I386_REL32;
+				default:
+					log.appendMsg(String.format(
+						"Unknown RelocationRelative width %d at %s", width, r.getAddress()));
+					return X86_32_CoffRelocationHandler.IMAGE_REL_I386_ABSOLUTE;
+			}
+		}
+		else {
+			log.appendMsg(String.format("Unknown relocation type %s at %s",
+				r.getClass().getSimpleName(), r.getAddress()));
+			return X86_32_CoffRelocationHandler.IMAGE_REL_I386_ABSOLUTE;
+		}
+	}
+
+	@Override
+	public boolean canApply(int machine) {
+		return machine == CoffMachineType.IMAGE_FILE_MACHINE_I386;
+	}
+}


### PR DESCRIPTION
About a month ago you mentioned on Hacker News that adding COFF support should be easy and fairly self-contained. You were right.

This is an implementation of the delinker exporter that outputs the Microsoft COFF format. It's still very rough around the edges but I was able to use it to successfully delink and relink an i386 Windows executable. Interestingly, with some careful delinking, I can take a program compiled by MSVC for Windows, delink it to ELF and relink it with glibc to make it run on Linux, and delink it to COFF and relink it with MinGW to make it run on Windows again. 🤯 

Feel free to leave a lot of comments. I can try to address comments, though I may take a bit depending on how busy I am. Not sure if you want to merge this upstream but I'm eager to get delinking into the world of Windows reverse engineering as it seems extremely promising for a wide variety of reverse engineering tasks.

Some notes:

- Only tested for i386; would love to make sure at least AMD64 and AArch64 work. If I could track down old WinNT ports to other architectures, I could try to get some of those working, too.
- Not tested with UNIX COFF. I don't have a toolchain to try it with. I think it is very plausible that we could make this exporter work for other COFF variants.
- I exported out some code that seemed sharable between different exporters. I'm not sure if I put them in good places. I am not a Java programmer :)