### PR TITLE
feat(coff): emit IMAGE_REL_AMD64_REL32_N for RIP-relative fields with trailing bytes

### DIFF
--- a/src/main/java/ghidra/app/analyzers/relocations/emitters/RelativeNextInstructionRelocationEmitter.java
+++ b/src/main/java/ghidra/app/analyzers/relocations/emitters/RelativeNextInstructionRelocationEmitter.java
@@ -56,8 +56,9 @@ public abstract class RelativeNextInstructionRelocationEmitter
 		Address address = instruction.getAddress().add(match.getOffset());
 		long addend = address.getUnsignedOffset() - target.getAddress().getUnsignedOffset() +
 			match.getValue();
+		int trailingBytes = instruction.getLength() - match.getOffset() - match.getSize();
 
 		relocationTable.addRelativePC(address, match.getSize(), match.getBitmask(),
-			target.getDestination(), addend);
+			target.getDestination(), addend, trailingBytes);
 	}
 }

--- a/src/main/java/ghidra/app/util/exporter/coff/relocs/X86_64_CoffRelocationTableBuilder.java
+++ b/src/main/java/ghidra/app/util/exporter/coff/relocs/X86_64_CoffRelocationTableBuilder.java
@@ -88,19 +88,42 @@ public class X86_64_CoffRelocationTableBuilder implements CoffRelocationTableBui
 		DataConverter dc = LittleEndianDataConverter.INSTANCE;
 		int width = relocation.getWidth();
 		long bitmask = relocation.getBitmask();
-		long value = relocation.getAddend() + width;
+		int trailingBytes = relocation.getTrailingBytes();
 
-		CoffRelocationType type;
-		if (width == 4 && bitmask == 0xffffffffL) {
-			type = CoffRelocationType_amd64.IMAGE_REL_AMD64_REL32;
-		}
-		else {
+		// MSVC encodes a RIP-relative field that is not the last operand (e.g. it is
+		// followed by an immediate) as IMAGE_REL_AMD64_REL32_N, whose reference point is
+		// the end of the instruction. The stored field is the bare symbol-relative addend;
+		// adding back width + trailingBytes cancels the next-instruction bias folded into
+		// the addend by the emitter, leaving exactly that value.
+		CoffRelocationType type = relativePcType(trailingBytes);
+		long value = relocation.getAddend() + width + trailingBytes;
+
+		if (width != 4 || bitmask != 0xffffffffL || type == null) {
 			logUnknownRelocation(relTable.getSection(), relocation, log);
 			return;
 		}
 
 		patchBytes(bytes, addressSet, dc, relocation, value);
 		emit(relTable, addressSet, relocation, type, symbol);
+	}
+
+	private static CoffRelocationType relativePcType(int trailingBytes) {
+		switch (trailingBytes) {
+			case 0:
+				return CoffRelocationType_amd64.IMAGE_REL_AMD64_REL32;
+			case 1:
+				return CoffRelocationType_amd64.IMAGE_REL_AMD64_REL32_1;
+			case 2:
+				return CoffRelocationType_amd64.IMAGE_REL_AMD64_REL32_2;
+			case 3:
+				return CoffRelocationType_amd64.IMAGE_REL_AMD64_REL32_3;
+			case 4:
+				return CoffRelocationType_amd64.IMAGE_REL_AMD64_REL32_4;
+			case 5:
+				return CoffRelocationType_amd64.IMAGE_REL_AMD64_REL32_5;
+			default:
+				return null;
+		}
 	}
 
 	private void emit(CoffRelocationTable relTable, AddressSetView addressSetView,

--- a/src/main/java/ghidra/program/model/relocobj/RelocationRelativePC.java
+++ b/src/main/java/ghidra/program/model/relocobj/RelocationRelativePC.java
@@ -17,6 +17,7 @@ import ghidra.program.model.address.Address;
 
 public class RelocationRelativePC extends AbstractRelocationBitmask {
 	private final boolean isTransparent;
+	private final int trailingBytes;
 
 	protected RelocationRelativePC(RelocationTable relocationTable, Address address, int width,
 			Address target, long addend) {
@@ -30,16 +31,40 @@ public class RelocationRelativePC extends AbstractRelocationBitmask {
 
 	protected RelocationRelativePC(RelocationTable relocationTable, Address address, int width,
 			Address target, long addend, boolean isTransparent) {
-		super(relocationTable, address, width, target, addend);
-
-		this.isTransparent = isTransparent;
+		this(relocationTable, address, width, target, addend, isTransparent, 0);
 	}
 
 	protected RelocationRelativePC(RelocationTable relocationTable, Address address, int width,
 			long bitmask, Address target, long addend, boolean isTransparent) {
+		this(relocationTable, address, width, bitmask, target, addend, isTransparent, 0);
+	}
+
+	protected RelocationRelativePC(RelocationTable relocationTable, Address address, int width,
+			Address target, long addend, boolean isTransparent, int trailingBytes) {
+		super(relocationTable, address, width, target, addend);
+
+		this.isTransparent = isTransparent;
+		this.trailingBytes = trailingBytes;
+	}
+
+	protected RelocationRelativePC(RelocationTable relocationTable, Address address, int width,
+			long bitmask, Address target, long addend, boolean isTransparent, int trailingBytes) {
 		super(relocationTable, address, width, bitmask, target, addend);
 
 		this.isTransparent = isTransparent;
+		this.trailingBytes = trailingBytes;
+	}
+
+	/**
+	 * Number of instruction bytes following the relocated field (for example a trailing
+	 * immediate operand). For x86-64 COFF this selects the IMAGE_REL_AMD64_REL32_N variant,
+	 * whose PC reference point is the end of the instruction rather than the end of the
+	 * field. Zero for the common case where the relocated field is the last operand.
+	 *
+	 * @return the number of trailing instruction bytes after the relocated field
+	 */
+	public int getTrailingBytes() {
+		return trailingBytes;
 	}
 
 	@Override

--- a/src/main/java/ghidra/program/model/relocobj/RelocationTable.java
+++ b/src/main/java/ghidra/program/model/relocobj/RelocationTable.java
@@ -223,6 +223,14 @@ public class RelocationTable {
 		return (RelocationRelativePC) add(rel);
 	}
 
+	public RelocationRelativePC addRelativePC(Address address, int width, long bitmask,
+			Address target, long addend, int trailingBytes) {
+		RelocationRelativePC rel =
+			new RelocationRelativePC(this, address, width, bitmask, target, addend, true,
+				trailingBytes);
+		return (RelocationRelativePC) add(rel);
+	}
+
 	public RelocationRelativeSymbol addRelativeSymbol(Address address, int width, Address target,
 			long addend, String relativetarget) {
 		RelocationRelativeSymbol rel = new RelocationRelativeSymbol(this, address, width,


### PR DESCRIPTION
## Problem

The x86-64 COFF relocation builder always emits `IMAGE_REL_AMD64_REL32` for
RIP-relative references, folding any post-field instruction bytes into the stored
displacement.

MSVC encodes this differently. When the relocated 4-byte field is **not** the last
bytes of the instruction — e.g. a RIP-relative memory operand combined with an
immediate, `imul eax, [rip+disp32], imm32` — the reference point for RIP is the end
of the *instruction*, which is `N` bytes past the end of the field. MSVC expresses
that with `IMAGE_REL_AMD64_REL32_N` (`REL32_1`..`REL32_5`) and stores the bare
symbol-relative addend in the field.

Emitting plain `REL32` with a baked-in `-N` displacement links to the same address,
but it does **not** reproduce MSVC's object files byte-for-byte. Tooling that pairs
relocations by type + addend (e.g. [objdiff](https://github.com/encounter/objdiff))
then reports a mismatch on every such instruction — e.g. `(REL32_4, +0)` from `cl`
vs `(REL32, -4)` from the delinker — even when the surrounding code is identical.

## Fix

Thread the trailing-byte count from the emitter (which has the `Instruction`) to the
x86-64 COFF builder:

- `RelativeNextInstructionRelocationEmitter` computes
  `N = instruction.getLength() - match.getOffset() - match.getSize()`.
- It is carried on `RelocationRelativePC` via a new `RelocationTable.addRelativePC(...)`
  overload. `N` defaults to `0`, so ELF, OMF and i386 COFF output is unchanged
  (i386 COFF has no `REL32_N` variants and keeps the existing behaviour).
- `X86_64_CoffRelocationTableBuilder` selects `IMAGE_REL_AMD64_REL32{,_1,_2,_3,_4,_5}`
  and writes `addend + width + N`, which reduces to the bare symbol-relative addend —
  matching MSVC. (`N == 0` produces byte-identical output to before.)

+65 / −8 across 4 files.

## Verification

Built against Ghidra 12.1 and exercised against delinked Windows 10 `ntoskrnl.exe`
objects, comparing the delinked target objects against the corresponding MSVC
(`cl.exe` 18.00, VS2013 U5) `.obj` files with objdiff:

| metric (244 objects) | result |
| --- | --- |
| objects that **regressed** | **0** |
| delinked targets byte-identical to before (N==0 path) | 221 |
| objects now emitting `REL32_N` | 23 |
| relocations emitted | 177× `REL32_1`, 44× `REL32_4` |

- A CRT `rand` translation unit (`imul eax, [seed], 214013`) now matches its MSVC
  object **byte-for-byte (100%)**; previously the lone `REL32_4` site was the only
  difference.
- `REL32_1` and `REL32_4` are both exercised; `REL32_2/3/5` are handled by the same
  path but are rare and did not occur in this corpus.

## Notes / follow-up

- A regression test against a real `cl.exe` fixture (a RIP-relative read-modify-write
  with an immediate, producing `REL32_4`) would be a good addition; happy to add one
  following the existing `coff_windows` test layout if you'd like it in this PR or a
  follow-up.
